### PR TITLE
Produce empty output in brief mode when no motes are detected

### DIFF
--- a/motelist.py
+++ b/motelist.py
@@ -67,7 +67,7 @@ class Motelist(object):
     def __str__(self):
         if len(self.__motes) == 0:
             if self.__brief:
-                return ' '
+                return ''
             else:
                 return 'No motes detected'
 
@@ -163,6 +163,9 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    print(str(Motelist(omit_header=args.omit_header,
-                       csv_out=args.csv,
-                       brief=args.brief)))
+    output = str(Motelist(omit_header=args.omit_header,
+                          csv_out=args.csv,
+                          brief=args.brief))
+
+    if output:
+        print(output)

--- a/motelist.py
+++ b/motelist.py
@@ -66,7 +66,10 @@ class Motelist(object):
 
     def __str__(self):
         if len(self.__motes) == 0:
-            return 'No motes detected'
+            if self.__brief:
+                return ' '
+            else:
+                return 'No motes detected'
 
         # Map output column headings to class Mote attribute names. Allows
         # us to easily change column text later, or re-order cols.


### PR DESCRIPTION
When no motes are detected we currently print a diagnostic message:

```
$ ./motelist.py 
No motes detected
```

This message appears even if we run with `--brief`. This PR changes the script such that this message is suppressed in brief mode.