### PR TITLE
Include usbserial among the default file patterns for macOS

### DIFF
--- a/backends/osx.py
+++ b/backends/osx.py
@@ -43,6 +43,7 @@ class OSXBackend(backends.backend.Backend):
     port_patterns = [
         '/dev/tty.SLAB*',
         '/dev/tty.usbmodem*',
+        '/dev/tty.usbserial*',
     ]
 
     search_attrs = {


### PR DESCRIPTION
Zolertia Firefly among others appear as /dev/tty.usbserial* under macOS.